### PR TITLE
Add optional scenario StopAfterFailureCount config

### DIFF
--- a/doc/Units.md
+++ b/doc/Units.md
@@ -63,6 +63,7 @@ Scenarios are distinct items that need to be tested.  There will probably be a "
 * WorkingDirectory: Directory to run the programs from.
 * Timeout: Maximum number of seconds this scenario should take.
 * Assume: A list of tests that are assumed to have passed.  Useful for making abbreviated unit tests.
+* StopAfterFailureCount: Number of tests that can fail before the scenario should stop running.
 
 
 .trigger

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -316,6 +316,7 @@ pub enum UnitDescriptionError {
     ParseError(ParserError),
     RegexError(self::regex::Error),
     HumantimeError(DurationError),
+    ParseIntError(std::num::ParseIntError),
     InvalidValue(
         String,      // Section name
         String,      // Key name
@@ -354,6 +355,12 @@ impl From<DurationError> for UnitDescriptionError {
     }
 }
 
+impl From<std::num::ParseIntError> for UnitDescriptionError {
+    fn from(error: std::num::ParseIntError) -> Self {
+        UnitDescriptionError::ParseIntError(error)
+    }
+}
+
 impl fmt::Display for UnitDescriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use std::error::Error;
@@ -376,6 +383,9 @@ impl fmt::Display for UnitDescriptionError {
             &UnitDescriptionError::RegexError(ref e) => write!(f, "unable to parse regex: {}", e),
             &UnitDescriptionError::MissingValue(ref sec, ref key) => {
                 write!(f, "key '{}' in section '{}' requires a value", key, sec)
+            }
+            &UnitDescriptionError::ParseIntError(ref e) => {
+                write!(f, "int parse error: {}", e.description())
             }
             &UnitDescriptionError::InvalidValue(ref sec, ref key, ref val, ref allowed) => write!(
                 f,


### PR DESCRIPTION
Finally got around to doing this, decided that @xobs proposal of a `StopAfterFailureCount` made the most sense as it allowed me to do what I would like to do (stop the tests as soon as any tests fail) in a more general way, that might be helpful for others.

Let me know if you disagree with my approach or I should change anything. I'm a rust noob, so it's quite likely I'm doing something wrong!

I've tested this on my local machine and it seems to work well (just with a few dumb test scripts that I change between `exit 0` and `exit 1`).

And btw - thanks again for making such a useful open source framework! We used exclave for our last test jig and it was massive step up from our previous hodge-podge method of chaining python scripts together. 