### PR TITLE
Start scenario on terminal 'enter' press

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,12 @@ fn main() {
                 .required(false)
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("KEYBOARD_TRIGGER")
+                .short("k")
+                .long("keyboard-trigger")
+                .help("Run default scenario on enter key press"),
+        )
         .get_matches();
 
     let config_dirs: Vec<_> = matches.values_of("CONFIG_DIR").unwrap().collect();
@@ -90,7 +96,7 @@ fn main() {
         None
     };
 
-    terminal::TerminalInterface::start(output_type, unit_broadcaster.subscribe());
+    terminal::TerminalInterface::start(output_type, &unit_broadcaster, matches.is_present("KEYBOARD_TRIGGER"));
 
     for config_dir in config_dirs {
         unit_watcher


### PR DESCRIPTION
This is a dinky little change (so let me know if it should be refactored or completely changed) but as I mention in the commit message, was really valuable in doing local dev in exclave. It optionally allows you to hit the enter key to run a scenario's tests, so that you don't need to implement a trigger/interface to start the tests. As well as for development, I imagine it'd also be useful for small test jigs that don't have physical buttons to start the test process. 

As always, happy to hear any critique/opinions.